### PR TITLE
Fix import of spreadsheet with numbers

### DIFF
--- a/html-src/src/utils.js
+++ b/html-src/src/utils.js
@@ -22,7 +22,7 @@ function parseSpreadsheet(data) {
     }
 
     // use xlsx.js to parse the spreadsheet data
-    let parsed = XLSX.read(data, { type: "array" });
+    let parsed = XLSX.read(data, { type: "array", dateNF: true, cellDates: true });
     let sheet = parsed.Sheets[parsed.SheetNames[0]];
     let sheetArray = XLSX.utils.sheet_to_json(sheet, { header: 1 });
 
@@ -44,6 +44,12 @@ function fillTemplate(template, spreadsheet, method = "nunjucks") {
                 // skip over non-string (likely null) headers
                 if (typeof key !== "string") {
                     continue;
+                }
+                if (typeof val === "number") {
+                    val = String(val);
+                }
+                if (val instanceof Date) {
+                    val = val.toLocaleDateString();
                 }
                 // assume non-string values are just ""
                 if (typeof val !== "string") {
@@ -72,7 +78,7 @@ function fillTemplate(template, spreadsheet, method = "nunjucks") {
 function fillTemplateNunjucks(template, subsArray) {
     let ret = [];
     let compiled = {};
-    // If autoescaping is turned on, then emails with `<...>` will become `&lt;...&gt;`
+    // If auto-escaping is turned on, then emails with `<...>` will become `&lt;...&gt;`
     const env = nunjucks.configure({ autoescape: false });
 
     // pre-compile the template for efficiency

--- a/html-src/src/utils.js
+++ b/html-src/src/utils.js
@@ -21,12 +21,40 @@ function parseSpreadsheet(data) {
         return [[]];
     }
 
-    // use xlsx.js to parse the spreadsheet data
-    let parsed = XLSX.read(data, { type: "array", dateNF: true, cellDates: true });
-    let sheet = parsed.Sheets[parsed.SheetNames[0]];
-    let sheetArray = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+    try {
+        // use xlsx.js to parse the spreadsheet data
+        let parsed = XLSX.read(data, {
+            type: "array",
+            dateNF: true,
+            cellDates: true,
+        });
+        let sheet = parsed.Sheets[parsed.SheetNames[0]];
+        let sheetArray = XLSX.utils.sheet_to_json(sheet, { header: 1 });
 
-    return sheetArray;
+        return sheetArray;
+    } catch (e) {
+        console.warn("Error when parsing spreading; using fallback", e);
+    }
+    // CSV parsing may fail when trying to process date cells, so we fall
+    // back to not processing the date cells.
+    try {
+        let parsed = XLSX.read(data, {
+            type: "array",
+        });
+        let sheet = parsed.Sheets[parsed.SheetNames[0]];
+        let sheetArray = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+
+        return sheetArray;
+    } catch (e) {
+        console.warn("Error when parsing spreading; no fallback available", e);
+    }
+
+    return [
+        ["!! Error parsing spreadsheet !!"],
+        [
+            "Try saving your spreadsheet in a different format (e.g. .xlsx or .ods)",
+        ],
+    ];
 }
 
 // Fill every item in template with data from spreadsheet

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "thunderbird-mail-merge",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "thunderbird-mail-merge",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "dependencies": {
                 "@handsontable/react": "2.1.0",
                 "classnames": "2.2.6",
@@ -14,6 +14,7 @@
                 "font-awesome": "4.7.0",
                 "handsontable": "10.0.0",
                 "nunjucks": "3.2.2",
+                "prettier": "^2.6.2",
                 "react": "16.12.0",
                 "react-app-rewired": "2.1.5",
                 "react-dom": "16.12.0",
@@ -13072,6 +13073,20 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/prettier": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/pretty-bytes": {
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -25795,6 +25810,11 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+        },
+        "prettier": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
         },
         "pretty-bytes": {
             "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "thunderbird-mail-merge",
-    "version": "2.1.0",
+    "version": "2.5.0",
     "description": "A Mail Merge extension for Thunderbird",
     "homepage": ".",
     "main": "src/index.js",
@@ -11,6 +11,7 @@
         "font-awesome": "4.7.0",
         "handsontable": "10.0.0",
         "nunjucks": "3.2.2",
+        "prettier": "^2.6.2",
         "react": "16.12.0",
         "react-app-rewired": "2.1.5",
         "react-dom": "16.12.0",

--- a/thunderbird-src/manifest.json
+++ b/thunderbird-src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_extensionName__",
     "description": "__MSG_extensionDescription__",
-    "version": "2.4",
+    "version": "2.5",
     "applications": {
         "gecko": {
             "id": "mailmergep@example.net",


### PR DESCRIPTION
Fixes issue #26 

Previous checks assumed any non-string value in a spreadsheet was `null`. Now additional checks for numbers and dates have been explicitly added, so importing spreadsheets with numbers and dates should work correctly.